### PR TITLE
Add OAuth controllers and module exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "passport-jwt": "^4.0.1",
         "passport-microsoft": "^2.1.0",
         "reflect-metadata": "^0.2.2",
-        "rxjs": "^7.8.1"
+        "rxjs": "^7.8.1",
+        "uuid": "^11.1.0"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.2.0",
@@ -11648,6 +11649,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "passport-jwt": "^4.0.1",
     "passport-microsoft": "^2.1.0",
     "reflect-metadata": "^0.2.2",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.1",
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",

--- a/src/controllers/apple-auth.controller.ts
+++ b/src/controllers/apple-auth.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Get, Inject, Req, Res, UseGuards } from '@nestjs/common';
-import { GoogleAuthGuard } from '../guards/google-auth.guard';
+import { AppleAuthGuard } from '../guards/apple-auth.guard';
 import {
   LOCKSMITH_AUTH_SERVICE,
   LocksmithModuleOptions,
@@ -7,8 +7,8 @@ import {
 import { ILocksmithAuthService } from '../services/locksmith-auth.service';
 import { AuthProvider } from '../enums';
 
-@Controller('auth/google')
-export class GoogleOauthController {
+@Controller('auth/apple')
+export class AppleOauthController {
   constructor(
     @Inject('LOCKSMITH_OPTIONS')
     private readonly options: LocksmithModuleOptions,
@@ -17,19 +17,19 @@ export class GoogleOauthController {
   ) {}
 
   @Get()
-  @UseGuards(GoogleAuthGuard)
-  async googleAuth() {
+  @UseGuards(AppleAuthGuard)
+  async appleAuth() {
     // Guard redirects
   }
 
   @Get('redirect')
-  @UseGuards(GoogleAuthGuard)
-  async googleAuthRedirect(@Req() req, @Res() res): Promise<any> {
+  @UseGuards(AppleAuthGuard)
+  async appleAuthRedirect(@Req() req, @Res() res): Promise<any> {
     /* eslint-disable @typescript-eslint/no-unsafe-argument */
     const { accessToken } = await this.authService.createExternalAccessToken(
       req.user,
       req.user?.providerId,
-      AuthProvider.Google,
+      AuthProvider.Apple,
     );
     /* eslint-enable @typescript-eslint/no-unsafe-argument */
     res.cookie(this.options?.jwt?.sessionCookieName, accessToken, {

--- a/src/controllers/index.ts
+++ b/src/controllers/index.ts
@@ -1,0 +1,3 @@
+export * from './google-auth.controller';
+export * from './microsoft-auth.controller';
+export * from './apple-auth.controller';

--- a/src/controllers/microsoft-auth.controller.ts
+++ b/src/controllers/microsoft-auth.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Get, Inject, Req, Res, UseGuards } from '@nestjs/common';
-import { GoogleAuthGuard } from '../guards/google-auth.guard';
+import { MicrosoftAuthGuard } from '../guards/microsoft-auth.guard';
 import {
   LOCKSMITH_AUTH_SERVICE,
   LocksmithModuleOptions,
@@ -7,8 +7,8 @@ import {
 import { ILocksmithAuthService } from '../services/locksmith-auth.service';
 import { AuthProvider } from '../enums';
 
-@Controller('auth/google')
-export class GoogleOauthController {
+@Controller('auth/microsoft')
+export class MicrosoftOauthController {
   constructor(
     @Inject('LOCKSMITH_OPTIONS')
     private readonly options: LocksmithModuleOptions,
@@ -17,19 +17,19 @@ export class GoogleOauthController {
   ) {}
 
   @Get()
-  @UseGuards(GoogleAuthGuard)
-  async googleAuth() {
+  @UseGuards(MicrosoftAuthGuard)
+  async microsoftAuth() {
     // Guard redirects
   }
 
   @Get('redirect')
-  @UseGuards(GoogleAuthGuard)
-  async googleAuthRedirect(@Req() req, @Res() res): Promise<any> {
+  @UseGuards(MicrosoftAuthGuard)
+  async microsoftAuthRedirect(@Req() req, @Res() res): Promise<any> {
     /* eslint-disable @typescript-eslint/no-unsafe-argument */
     const { accessToken } = await this.authService.createExternalAccessToken(
       req.user,
       req.user?.providerId,
-      AuthProvider.Google,
+      AuthProvider.Microsoft,
     );
     /* eslint-enable @typescript-eslint/no-unsafe-argument */
     res.cookie(this.options?.jwt?.sessionCookieName, accessToken, {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,4 @@ export * from './locksmith.module';
 export * from './strategies';
 export * from './enums';
 export * from './services/locksmith-auth.service';
+export * from './controllers';

--- a/src/locksmith-auth.service.spec.ts
+++ b/src/locksmith-auth.service.spec.ts
@@ -9,14 +9,17 @@ describe('LocksmithAuthService', () => {
       imports: [JwtModule.register({ secret: 'test' })],
       providers: [
         LocksmithAuthService,
-        { provide: 'LOCKSMITH_OPTIONS', useValue: { issuerName: 'MyApp' } },
+        {
+          provide: 'LOCKSMITH_OPTIONS',
+          useValue: { jwt: { issuerName: 'MyApp' } },
+        },
       ],
     }).compile();
 
     const service = moduleRef.get<LocksmithAuthService>(LocksmithAuthService);
     const jwtService = moduleRef.get(JwtService);
 
-    const payload: JwtPayload = { sub: 1, username: 'bob' };
+    const payload: JwtPayload = { sub: '1', username: 'bob' };
     const { accessToken } = await service.createAccessToken(payload);
     const decoded = jwtService.verify(accessToken);
     expect(decoded.iss).toBe('MyApp');

--- a/src/locksmith.module.ts
+++ b/src/locksmith.module.ts
@@ -9,6 +9,9 @@ import { JwtAuthStrategy } from './strategies/jwt.strategy';
 import { AppleAuthGuard } from './guards/apple-auth.guard';
 import { AppleAuthStrategy } from './strategies/apple-auth.strategy';
 import { LocksmithAuthService } from './services/locksmith-auth.service';
+import { GoogleOauthController } from './controllers/google-auth.controller';
+import { MicrosoftOauthController } from './controllers/microsoft-auth.controller';
+import { AppleOauthController } from './controllers/apple-auth.controller';
 
 export interface OAuthOptions {
   clientID: string;
@@ -48,6 +51,7 @@ export class LocksmithModule {
     const imports: Array<any> = [];
     const exports: Array<any> = [];
     const providers: Array<any> = [];
+    const controllers: Array<any> = [];
 
     // Initialize JWT if options were provided
     if (options?.jwt) {
@@ -66,16 +70,19 @@ export class LocksmithModule {
     if (options?.external?.apple) {
       exports.push(AppleAuthGuard, AppleAuthStrategy);
       providers.push(AppleAuthGuard, AppleAuthStrategy);
+      controllers.push(AppleOauthController);
     }
 
     if (options?.external?.google) {
       exports.push(GoogleAuthGuard, GoogleAuthStrategy);
       providers.push(GoogleAuthGuard, GoogleAuthStrategy);
+      controllers.push(GoogleOauthController);
     }
 
     if (options?.external?.microsoft) {
       exports.push(MicrosoftAuthGuard, MicrosoftAuthStrategy);
       providers.push(MicrosoftAuthGuard, MicrosoftAuthStrategy);
+      controllers.push(MicrosoftOauthController);
     }
 
     // Custom Locksmith Options Provider
@@ -93,6 +100,7 @@ export class LocksmithModule {
     return {
       module: LocksmithModule,
       imports,
+      controllers,
       exports,
       providers,
     };

--- a/src/strategies/google-auth.strategy.ts
+++ b/src/strategies/google-auth.strategy.ts
@@ -13,10 +13,12 @@ export class GoogleAuthStrategy extends PassportStrategy(
     @Inject('LOCKSMITH_OPTIONS')
     private readonly options: LocksmithModuleOptions,
   ) {
+    /* eslint-disable @typescript-eslint/no-unsafe-argument */
     super({
       ...(options?.external?.google as any),
       scope: ['email', 'profile'],
-    } as any);
+    });
+    /* eslint-enable @typescript-eslint/no-unsafe-argument */
   }
 
   validate(_accessToken: string, _refreshToken: string, profile: Profile) {

--- a/src/strategies/jwt.strategy.ts
+++ b/src/strategies/jwt.strategy.ts
@@ -2,7 +2,6 @@ import { Strategy } from 'passport-jwt';
 import { PassportStrategy } from '@nestjs/passport';
 import { Inject, Injectable } from '@nestjs/common';
 import { LocksmithModuleOptions } from '../locksmith.module';
-import { JwtService } from '@nestjs/jwt';
 
 export interface JwtPayload {
   /**

--- a/src/strategies/microsoft-auth.strategy.ts
+++ b/src/strategies/microsoft-auth.strategy.ts
@@ -18,10 +18,12 @@ export class MicrosoftAuthStrategy extends PassportStrategy(
     @Inject('LOCKSMITH_OPTIONS')
     private readonly options: LocksmithModuleOptions,
   ) {
+    /* eslint-disable @typescript-eslint/no-unsafe-argument */
     super({
       ...(options?.external?.microsoft as any),
       scope: ['user.read'],
-    } as any);
+    });
+    /* eslint-enable @typescript-eslint/no-unsafe-argument */
   }
 
   validate(


### PR DESCRIPTION
## Summary
- add controllers for Google, Microsoft and Apple OAuth flows
- hook controllers into `LocksmithModule`
- expose controllers from module public API
- fix JWT issuer test
- remove unused imports and tweak strategies for lint

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684c5b00ade88322b3e4c954caef1df4