### PR TITLE
Include profile data in Google OAuth tokens

### DIFF
--- a/src/controllers/google-auth.controller.ts
+++ b/src/controllers/google-auth.controller.ts
@@ -26,8 +26,13 @@ export class GoogleOauthController {
   @UseGuards(GoogleAuthGuard)
   async googleAuthRedirect(@Req() req, @Res() res): Promise<any> {
     /* eslint-disable @typescript-eslint/no-unsafe-argument */
+    const payload = {
+      sub: req.user?.username,
+      username: req.user?.username,
+      name: req.user?.name,
+    };
     const { accessToken } = await this.authService.createExternalAccessToken(
-      req.user,
+      payload,
       req.user?.providerId,
       AuthProvider.Google,
     );


### PR DESCRIPTION
## Summary
- return user info from Google OAuth profile in the access token

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684c797472048322953cd9e2d59019c6