### PR TITLE
Add unit tests for OAuth strategies and controllers

### DIFF
--- a/src/controllers/oauth-controllers.spec.ts
+++ b/src/controllers/oauth-controllers.spec.ts
@@ -1,0 +1,55 @@
+import { GoogleOauthController } from './google-auth.controller';
+import { MicrosoftOauthController } from './microsoft-auth.controller';
+import { AppleOauthController } from './apple-auth.controller';
+import { AuthProvider } from '../enums';
+
+describe('OAuth Controllers', () => {
+  const options = { jwt: { sessionCookieName: 'sid' } } as any;
+
+  let authService: { createExternalAccessToken: jest.Mock };
+  let res: { cookie: jest.Mock; redirect: jest.Mock };
+
+  beforeEach(() => {
+    authService = {
+      createExternalAccessToken: jest.fn().mockResolvedValue({ accessToken: 'token' }),
+    };
+    res = { cookie: jest.fn(), redirect: jest.fn() } as any;
+  });
+
+  it('googleAuthRedirect creates token and sets cookie', async () => {
+    const controller = new GoogleOauthController(options, authService as any);
+    const req: any = { user: { providerId: 'gid', name: 'Bob', username: 'bob@test.com' } };
+    await controller.googleAuthRedirect(req, res as any);
+    expect(authService.createExternalAccessToken).toHaveBeenCalledWith(
+      { sub: 'bob@test.com', username: 'bob@test.com', name: 'Bob' },
+      'gid',
+      AuthProvider.Google,
+    );
+    expect(res.cookie).toHaveBeenCalledWith('sid', 'token', { httpOnly: true, sameSite: 'lax' });
+    expect(res.redirect).toHaveBeenCalledWith('/profile');
+  });
+
+  it('microsoftAuthRedirect creates token and sets cookie', async () => {
+    const controller = new MicrosoftOauthController(options, authService as any);
+    const req: any = { user: { providerId: 'mid', username: 'alice@ms.com', name: 'Alice' } };
+    await controller.microsoftAuthRedirect(req, res as any);
+    expect(authService.createExternalAccessToken).toHaveBeenCalledWith(
+      req.user,
+      'mid',
+      AuthProvider.Microsoft,
+    );
+    expect(res.cookie).toHaveBeenCalledWith('sid', 'token', { httpOnly: true, sameSite: 'lax' });
+  });
+
+  it('appleAuthRedirect creates token and sets cookie', async () => {
+    const controller = new AppleOauthController(options, authService as any);
+    const req: any = { user: { providerId: 'aid', username: 'apple@test.com' } };
+    await controller.appleAuthRedirect(req, res as any);
+    expect(authService.createExternalAccessToken).toHaveBeenCalledWith(
+      req.user,
+      'aid',
+      AuthProvider.Apple,
+    );
+    expect(res.cookie).toHaveBeenCalledWith('sid', 'token', { httpOnly: true, sameSite: 'lax' });
+  });
+});

--- a/src/strategies/oauth-strategies.spec.ts
+++ b/src/strategies/oauth-strategies.spec.ts
@@ -1,0 +1,75 @@
+import { GoogleAuthStrategy } from './google-auth.strategy';
+import { MicrosoftAuthStrategy, MicrosoftProfile } from './microsoft-auth.strategy';
+import { AppleAuthStrategy } from './apple-auth.strategy';
+import { JwtService } from '@nestjs/jwt';
+
+describe('OAuth Strategies', () => {
+  it('GoogleAuthStrategy.validate returns payload', async () => {
+    const strategy = new GoogleAuthStrategy({
+      external: {
+        google: { clientID: 'id', clientSecret: 'secret', callbackURL: 'http://localhost' },
+      },
+    });
+    const profile: any = {
+      id: '123',
+      name: { givenName: 'Bob' },
+      emails: [{ value: 'bob@test.com', verified: true }],
+    };
+    const result = await strategy.validate('', '', profile);
+    expect(result).toEqual({
+      provider: 'google',
+      providerId: '123',
+      name: 'Bob',
+      username: 'bob@test.com',
+    });
+  });
+
+  it('MicrosoftAuthStrategy.validate returns payload', async () => {
+    const strategy = new MicrosoftAuthStrategy({
+      external: {
+        microsoft: { clientID: 'id', clientSecret: 'secret', callbackURL: 'http://localhost' },
+      },
+    });
+    const profile: MicrosoftProfile = {
+      id: '456',
+      displayName: 'Alice',
+      userPrincipalName: 'alice@ms.com',
+    } as MicrosoftProfile;
+    const result = await strategy.validate('', '', profile);
+    expect(result).toEqual({
+      provider: 'microsoft',
+      providerId: '456',
+      name: 'Alice',
+      username: 'alice@ms.com',
+    });
+  });
+
+  it('AppleAuthStrategy.validate returns payload', async () => {
+    const jwtService = {
+      decode: jest.fn().mockReturnValue({ email: 'app@test.com', email_verified: true }),
+    } as unknown as JwtService;
+    const strategy = new AppleAuthStrategy(
+      {
+        external: {
+          apple: {
+            clientID: 'id',
+            teamID: 'team',
+            callbackURL: 'http://localhost',
+            keyID: 'key',
+            privateKeyString: 'private',
+            passReqToCallback: true,
+          },
+        },
+      },
+      jwtService,
+    );
+    const profile: any = { id: '789' };
+    const result = await strategy.validate('', '', 'idToken', profile);
+    expect(jwtService.decode).toHaveBeenCalledWith('idToken', { json: true });
+    expect(result).toEqual({
+      provider: 'apple',
+      providerId: '789',
+      username: 'app@test.com',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add coverage for Google, Microsoft and Apple auth strategies
- verify OAuth controllers create external tokens and set session cookies

## Testing
- `npm test -- -w=1`

------
https://chatgpt.com/codex/tasks/task_e_684c7b851e1083229ddfcbf271ecb7b1