### PR TITLE
Update test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,11 @@ In order to support and configure each external auth provider, you will need to 
 
 ## Testing
 
+Install dependencies before running tests:
+
 ```bash
+$ npm install
+
 # unit tests
 $ npm run test
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
-    "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand"
+    "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
+    "pretest": "node scripts/check-deps.js"
   },
   "dependencies": {
     "@nestjs/common": "^11.0.16",

--- a/scripts/check-deps.js
+++ b/scripts/check-deps.js
@@ -1,0 +1,5 @@
+const fs = require('fs');
+if (!fs.existsSync('node_modules')) {
+  console.error('Dependencies not installed. Run "npm install".');
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- mention installing dependencies before running tests in README
- add pretest check that warns if `node_modules` is missing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cacd944348322807581665b7cce5c