### PR TITLE
Add session clearing helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ export class AuthController {
   ) {}
 
   @Post('login')
-  async login(@Body() user: any, @Res() res: Response) {
+  async login(@Body() user: any, @Res() res: any) {
     // perform your own credential checks here
     const { accessToken } = await this.auth.createAccessToken({
       sub: user.id,
@@ -95,6 +95,20 @@ export class AuthController {
     });
     return res.sendStatus(200);
   }
+}
+```
+
+### Clearing the session cookie
+
+To remove the JWT session cookie during logout, call `clearSessionCookie` on
+`LocksmithAuthService` with the response or reply object used by Express or
+Fastify:
+
+```typescript
+@Post('logout')
+logout(@Res() res: any) {
+  this.auth.clearSessionCookie(res);
+  return res.sendStatus(200);
 }
 ```
 

--- a/src/locksmith-auth.service.spec.ts
+++ b/src/locksmith-auth.service.spec.ts
@@ -25,4 +25,22 @@ describe('LocksmithAuthService', () => {
     expect(decoded.iss).toBe('MyApp');
     expect(decoded.jti).toBeDefined();
   });
+
+  it('clears the configured session cookie', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [JwtModule.register({ secret: 'test' })],
+      providers: [
+        LocksmithAuthService,
+        {
+          provide: 'LOCKSMITH_OPTIONS',
+          useValue: { jwt: { sessionCookieName: 'MyCookie' } },
+        },
+      ],
+    }).compile();
+
+    const service = moduleRef.get<LocksmithAuthService>(LocksmithAuthService);
+    const res = { clearCookie: jest.fn() } as any;
+    service.clearSessionCookie(res);
+    expect(res.clearCookie).toHaveBeenCalledWith('MyCookie');
+  });
 });

--- a/src/services/locksmith-auth.service.ts
+++ b/src/services/locksmith-auth.service.ts
@@ -18,6 +18,7 @@ export interface ILocksmithAuthService {
     externalId: string,
     authProvider: AuthProvider,
   ): Promise<AccessToken>;
+  clearSessionCookie(res: { clearCookie?: (name: string, options?: any) => any }): void;
 }
 
 @Injectable()
@@ -75,5 +76,12 @@ export class LocksmithAuthService implements ILocksmithAuthService {
     if (!tokenPayload.jti) tokenPayload.jti = uuid();
     const accessToken = await this.jwtService.signAsync(tokenPayload);
     return { accessToken };
+  }
+
+  clearSessionCookie(res: { clearCookie?: (name: string, options?: any) => any }): void {
+    const name = this.options?.jwt?.sessionCookieName;
+    if (name && typeof res.clearCookie === 'function') {
+      res.clearCookie(name);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- provide a method to clear the configured session cookie
- test the cookie clearing behavior
- document how to clear the session cookie
- ensure the helper works with Express or Fastify

## Testing
- `npx jest --ci --runInBand > /tmp/test.log 2>&1 && tail -n 20 /tmp/test.log`

------
https://chatgpt.com/codex/tasks/task_e_684cacbe15108322a119dc5fcaefca9a