### PR TITLE
Add async init for LocksmithModule

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,25 @@ LocksmithModule.forRoot({
 }),
 ```
 
+Alternatively, you can load configuration asynchronously using Nest's
+`ConfigModule`:
+
+```typescript
+import { ConfigModule, ConfigService } from '@nestjs/config';
+
+LocksmithModule.forRootAsync({
+  imports: [ConfigModule.forRoot()],
+  useFactory: (config: ConfigService) => ({
+    jwt: {
+      secret: config.get<string>('JWT_SECRET'),
+      expiresIn: config.get<number>('JWT_EXPIRES_IN'),
+      sessionCookieName: 'MyAppSession',
+    },
+  }),
+  inject: [ConfigService],
+}),
+```
+
 Each authentication mechanism is activated by providing it's respective configuration value in the `LocksmithModuleOptions` provided to the `LocksmithModule`. Omitting `jwt`, `external.apple`, `external.google`, or `external.microsoft`, or `external` entirely, will disable support for that functionality and the respective AuthGuards and Passport strategies will not be registered by the `LocksmithModule` with the NestJS dependency container.
 
 ### 2. Use the built-in OAuth controllers

--- a/src/controllers/oauth-controllers.spec.ts
+++ b/src/controllers/oauth-controllers.spec.ts
@@ -2,54 +2,84 @@ import { GoogleOauthController } from './google-auth.controller';
 import { MicrosoftOauthController } from './microsoft-auth.controller';
 import { AppleOauthController } from './apple-auth.controller';
 import { AuthProvider } from '../enums';
+import { LocksmithModuleOptions } from '../locksmith.module';
+import { ILocksmithAuthService } from '../services/locksmith-auth.service';
 
 describe('OAuth Controllers', () => {
-  const options = { jwt: { sessionCookieName: 'sid' } } as any;
+  const options: LocksmithModuleOptions = {
+    jwt: { sessionCookieName: 'sid', expiresIn: 0, secret: 'test' },
+  };
 
   let authService: { createExternalAccessToken: jest.Mock };
   let res: { cookie: jest.Mock; redirect: jest.Mock };
 
   beforeEach(() => {
     authService = {
-      createExternalAccessToken: jest.fn().mockResolvedValue({ accessToken: 'token' }),
+      createExternalAccessToken: jest
+        .fn()
+        .mockResolvedValue({ accessToken: 'token' }),
     };
     res = { cookie: jest.fn(), redirect: jest.fn() } as any;
   });
 
   it('googleAuthRedirect creates token and sets cookie', async () => {
-    const controller = new GoogleOauthController(options, authService as any);
-    const req: any = { user: { providerId: 'gid', name: 'Bob', username: 'bob@test.com' } };
+    const controller = new GoogleOauthController(
+      options,
+      authService as unknown as ILocksmithAuthService,
+    );
+    const req: any = {
+      user: { providerId: 'gid', name: 'Bob', username: 'bob@test.com' },
+    };
     await controller.googleAuthRedirect(req, res as any);
     expect(authService.createExternalAccessToken).toHaveBeenCalledWith(
       { sub: 'bob@test.com', username: 'bob@test.com', name: 'Bob' },
       'gid',
       AuthProvider.Google,
     );
-    expect(res.cookie).toHaveBeenCalledWith('sid', 'token', { httpOnly: true, sameSite: 'lax' });
+    expect(res.cookie).toHaveBeenCalledWith('sid', 'token', {
+      httpOnly: true,
+      sameSite: 'lax',
+    });
     expect(res.redirect).toHaveBeenCalledWith('/profile');
   });
 
   it('microsoftAuthRedirect creates token and sets cookie', async () => {
-    const controller = new MicrosoftOauthController(options, authService as any);
-    const req: any = { user: { providerId: 'mid', username: 'alice@ms.com', name: 'Alice' } };
+    const controller = new MicrosoftOauthController(
+      options,
+      authService as unknown as ILocksmithAuthService,
+    );
+    const req: any = {
+      user: { providerId: 'mid', username: 'alice@ms.com', name: 'Alice' },
+    };
     await controller.microsoftAuthRedirect(req, res as any);
     expect(authService.createExternalAccessToken).toHaveBeenCalledWith(
       req.user,
       'mid',
       AuthProvider.Microsoft,
     );
-    expect(res.cookie).toHaveBeenCalledWith('sid', 'token', { httpOnly: true, sameSite: 'lax' });
+    expect(res.cookie).toHaveBeenCalledWith('sid', 'token', {
+      httpOnly: true,
+      sameSite: 'lax',
+    });
   });
 
   it('appleAuthRedirect creates token and sets cookie', async () => {
-    const controller = new AppleOauthController(options, authService as any);
-    const req: any = { user: { providerId: 'aid', username: 'apple@test.com' } };
+    const controller = new AppleOauthController(
+      options,
+      authService as unknown as ILocksmithAuthService,
+    );
+    const req: any = {
+      user: { providerId: 'aid', username: 'apple@test.com' },
+    };
     await controller.appleAuthRedirect(req, res as any);
     expect(authService.createExternalAccessToken).toHaveBeenCalledWith(
       req.user,
       'aid',
       AuthProvider.Apple,
     );
-    expect(res.cookie).toHaveBeenCalledWith('sid', 'token', { httpOnly: true, sameSite: 'lax' });
+    expect(res.cookie).toHaveBeenCalledWith('sid', 'token', {
+      httpOnly: true,
+      sameSite: 'lax',
+    });
   });
 });

--- a/src/dummy.spec.ts
+++ b/src/dummy.spec.ts
@@ -1,1 +1,5 @@
-describe("dummy", () => { it("passes", () => { expect(true).toBe(true); }); });
+describe('dummy', () => {
+  it('passes', () => {
+    expect(true).toBe(true);
+  });
+});

--- a/src/locksmith.module.ts
+++ b/src/locksmith.module.ts
@@ -1,4 +1,12 @@
-import { DynamicModule, Logger, Provider } from '@nestjs/common';
+import {
+  DynamicModule,
+  Logger,
+  Provider,
+  Module,
+  ModuleMetadata,
+  Type,
+} from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
 import { JwtModule } from '@nestjs/jwt';
 import { JwtAuthGuard } from './guards/jwt.guard';
 import { GoogleAuthGuard } from './guards/google-auth.guard';
@@ -44,6 +52,22 @@ export interface LocksmithModuleOptions {
       passReqToCallback: boolean;
     };
   };
+}
+
+export interface LocksmithOptionsFactory {
+  createLocksmithOptions():
+    | Promise<LocksmithModuleOptions>
+    | LocksmithModuleOptions;
+}
+
+export interface LocksmithModuleAsyncOptions
+  extends Pick<ModuleMetadata, 'imports'> {
+  useExisting?: Type<LocksmithOptionsFactory>;
+  useClass?: Type<LocksmithOptionsFactory>;
+  useFactory?: (
+    ...args: any[]
+  ) => Promise<LocksmithModuleOptions> | LocksmithModuleOptions;
+  inject?: any[];
 }
 
 export class LocksmithModule {
@@ -104,5 +128,50 @@ export class LocksmithModule {
       exports,
       providers,
     };
+  }
+
+  private static async createOptionsFromAsync(
+    asyncOptions: LocksmithModuleAsyncOptions,
+  ): Promise<LocksmithModuleOptions | undefined> {
+    @Module({
+      imports: asyncOptions.imports ?? [],
+      providers: asyncOptions.useClass
+        ? [{ provide: asyncOptions.useClass, useClass: asyncOptions.useClass }]
+        : [],
+    })
+    class TempModule {}
+
+    const app = await NestFactory.createApplicationContext(TempModule, {
+      logger: false,
+    });
+    try {
+      if (asyncOptions.useFactory) {
+        const deps: unknown[] = await Promise.all(
+          (asyncOptions.inject ?? []).map((dep) =>
+            app.get<unknown>(
+              dep as
+                | string
+                | symbol
+                | (new (...args: any[]) => unknown)
+                | Type<unknown>,
+            ),
+          ),
+        );
+        return await asyncOptions.useFactory(...deps);
+      }
+      const optionsFactory = app.get<LocksmithOptionsFactory>(
+        asyncOptions.useExisting ?? asyncOptions.useClass!,
+      );
+      return await optionsFactory.createLocksmithOptions();
+    } finally {
+      await app.close();
+    }
+  }
+
+  static async forRootAsync(
+    options: LocksmithModuleAsyncOptions,
+  ): Promise<DynamicModule> {
+    const resolvedOptions = await this.createOptionsFromAsync(options);
+    return this.forRoot(resolvedOptions);
   }
 }

--- a/src/strategies/apple-auth.strategy.ts
+++ b/src/strategies/apple-auth.strategy.ts
@@ -26,7 +26,6 @@ export class AppleAuthStrategy extends PassportStrategy(
     idToken: string,
     profile,
   ) {
-
     // Validate JWT token with Apple JWK keys
 
     const decodedToken = this.jwtService.decode(idToken, { json: true });

--- a/src/strategies/oauth-strategies.spec.ts
+++ b/src/strategies/oauth-strategies.spec.ts
@@ -1,21 +1,29 @@
 import { GoogleAuthStrategy } from './google-auth.strategy';
-import { MicrosoftAuthStrategy, MicrosoftProfile } from './microsoft-auth.strategy';
+import { Profile } from 'passport-google-oauth20';
+import {
+  MicrosoftAuthStrategy,
+  MicrosoftProfile,
+} from './microsoft-auth.strategy';
 import { AppleAuthStrategy } from './apple-auth.strategy';
 import { JwtService } from '@nestjs/jwt';
 
 describe('OAuth Strategies', () => {
-  it('GoogleAuthStrategy.validate returns payload', async () => {
+  it('GoogleAuthStrategy.validate returns payload', () => {
     const strategy = new GoogleAuthStrategy({
       external: {
-        google: { clientID: 'id', clientSecret: 'secret', callbackURL: 'http://localhost' },
+        google: {
+          clientID: 'id',
+          clientSecret: 'secret',
+          callbackURL: 'http://localhost',
+        },
       },
     });
-    const profile: any = {
+    const profile: Profile = {
       id: '123',
       name: { givenName: 'Bob' },
       emails: [{ value: 'bob@test.com', verified: true }],
-    };
-    const result = await strategy.validate('', '', profile);
+    } as Profile;
+    const result = strategy.validate('', '', profile);
     expect(result).toEqual({
       provider: 'google',
       providerId: '123',
@@ -24,10 +32,14 @@ describe('OAuth Strategies', () => {
     });
   });
 
-  it('MicrosoftAuthStrategy.validate returns payload', async () => {
+  it('MicrosoftAuthStrategy.validate returns payload', () => {
     const strategy = new MicrosoftAuthStrategy({
       external: {
-        microsoft: { clientID: 'id', clientSecret: 'secret', callbackURL: 'http://localhost' },
+        microsoft: {
+          clientID: 'id',
+          clientSecret: 'secret',
+          callbackURL: 'http://localhost',
+        },
       },
     });
     const profile: MicrosoftProfile = {
@@ -35,7 +47,7 @@ describe('OAuth Strategies', () => {
       displayName: 'Alice',
       userPrincipalName: 'alice@ms.com',
     } as MicrosoftProfile;
-    const result = await strategy.validate('', '', profile);
+    const result = strategy.validate('', '', profile);
     expect(result).toEqual({
       provider: 'microsoft',
       providerId: '456',
@@ -44,9 +56,11 @@ describe('OAuth Strategies', () => {
     });
   });
 
-  it('AppleAuthStrategy.validate returns payload', async () => {
+  it('AppleAuthStrategy.validate returns payload', () => {
     const jwtService = {
-      decode: jest.fn().mockReturnValue({ email: 'app@test.com', email_verified: true }),
+      decode: jest
+        .fn()
+        .mockReturnValue({ email: 'app@test.com', email_verified: true }),
     } as unknown as JwtService;
     const strategy = new AppleAuthStrategy(
       {
@@ -64,8 +78,12 @@ describe('OAuth Strategies', () => {
       jwtService,
     );
     const profile: any = { id: '789' };
-    const result = await strategy.validate('', '', 'idToken', profile);
-    expect(jwtService.decode).toHaveBeenCalledWith('idToken', { json: true });
+    const result = strategy.validate('', '', 'idToken', profile);
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    const decode = jwtService.decode as jest.Mock;
+    expect(decode).toHaveBeenCalledWith('idToken', {
+      json: true,
+    });
     expect(result).toEqual({
       provider: 'apple',
       providerId: '789',


### PR DESCRIPTION
## Summary
- allow LocksmithModule to be initialized asynchronously
- demonstrate using ConfigModule for configuration
- update tests for lint compatibility

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cacb845c483229a85f57003bee8e3