### PR TITLE
Handle cookie options in session clearing

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ LocksmithModule.forRoot({
 
 Optionally, `redirectPath` controls where users are redirected after a successful
 OAuth login, and `cookieOptions` are passed directly to Express when
-setting the session cookie.
+setting and clearing the session cookie.
 
 Alternatively, you can load configuration asynchronously using Nest's
 `ConfigModule`:
@@ -139,7 +139,7 @@ export class ProfileController {
 
 To remove the JWT session cookie during logout, call `clearSessionCookie` on
 `LocksmithAuthService` with the response or reply object used by Express or
-Fastify:
+Fastify. Any `cookieOptions` provided to `LocksmithModule` are also passed when clearing the cookie:
 
 ```typescript
 @Post('logout')

--- a/src/services/locksmith-auth.service.spec.ts
+++ b/src/services/locksmith-auth.service.spec.ts
@@ -43,4 +43,28 @@ describe('LocksmithAuthService', () => {
     service.clearSessionCookie(res);
     expect(res.clearCookie).toHaveBeenCalledWith('MyCookie');
   });
+
+  it('passes cookie options when clearing the session cookie', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [JwtModule.register({ secret: 'test' })],
+      providers: [
+        LocksmithAuthService,
+        {
+          provide: 'LOCKSMITH_OPTIONS',
+          useValue: {
+            jwt: { sessionCookieName: 'MyCookie' },
+            cookieOptions: { path: '/app', domain: 'example.com' } as any,
+          },
+        },
+      ],
+    }).compile();
+
+    const service = moduleRef.get<LocksmithAuthService>(LocksmithAuthService);
+    const res = { clearCookie: jest.fn() } as any;
+    service.clearSessionCookie(res);
+    expect(res.clearCookie).toHaveBeenCalledWith('MyCookie', {
+      path: '/app',
+      domain: 'example.com',
+    });
+  });
 });

--- a/src/services/locksmith-auth.service.ts
+++ b/src/services/locksmith-auth.service.ts
@@ -81,7 +81,9 @@ export class LocksmithAuthService implements ILocksmithAuthService {
   clearSessionCookie(res: { clearCookie?: (name: string, options?: any) => any }): void {
     const name = this.options?.jwt?.sessionCookieName;
     if (name && typeof res.clearCookie === 'function') {
-      res.clearCookie(name);
+      const opts = this.options?.cookieOptions;
+      if (opts) res.clearCookie(name, opts);
+      else res.clearCookie(name);
     }
   }
 }


### PR DESCRIPTION
## Summary
- pass `cookieOptions` to `clearSessionCookie`
- test clearing cookies with options
- document clearing cookie options

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cb630d3e08322a861d90c0406ad3b