### PR TITLE
Improve Fastify compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ LocksmithModule.forRoot({
 ```
 
 Optionally, `redirectPath` controls where users are redirected after a successful
-OAuth login, and `cookieOptions` are passed directly to Express when
-setting and clearing the session cookie.
+OAuth login. `cookieOptions` are forwarded to the Express `response.cookie`
+method or Fastify's `reply.cookie` when setting and clearing the session cookie.
 
 Alternatively, you can load configuration asynchronously using Nest's
 `ConfigModule`:

--- a/src/fastify-compat.spec.ts
+++ b/src/fastify-compat.spec.ts
@@ -1,0 +1,49 @@
+import { Test } from '@nestjs/testing';
+import { JwtModule, JwtService } from '@nestjs/jwt';
+import { LocksmithAuthService } from './services/locksmith-auth.service';
+import { GoogleOauthController } from './controllers/google-auth.controller';
+import { LOCKSMITH_AUTH_SERVICE, LocksmithModuleOptions } from './locksmith.module';
+import { AuthProvider } from './enums';
+import { ILocksmithAuthService } from './services/locksmith-auth.service';
+
+
+describe('Fastify compatibility', () => {
+  it('clearSessionCookie supports Fastify reply', async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [JwtModule.register({ secret: 'test' })],
+      providers: [
+        LocksmithAuthService,
+        { provide: 'LOCKSMITH_OPTIONS', useValue: { jwt: { sessionCookieName: 'sid' }, cookieOptions: { path: '/app' } } },
+      ],
+    }).compile();
+
+    const service = moduleRef.get<LocksmithAuthService>(LocksmithAuthService);
+    const reply: any = { clearCookie: jest.fn() };
+    service.clearSessionCookie(reply);
+    expect(reply.clearCookie).toHaveBeenCalledWith('sid', { path: '/app' });
+  });
+
+  it('googleAuthRedirect works with Fastify reply', async () => {
+    const options: LocksmithModuleOptions = {
+      jwt: { sessionCookieName: 'sid' } as any,
+      cookieOptions: { secure: false } as any,
+      redirectPath: '/home',
+    };
+    const authService: ILocksmithAuthService = {
+      createExternalAccessToken: jest.fn().mockResolvedValue({ accessToken: 'token' }),
+      createAccessToken: jest.fn(),
+      clearSessionCookie: jest.fn(),
+    };
+    const controller = new GoogleOauthController(options, authService);
+    const req: any = { user: { providerId: 'gid', username: 'bob@test.com', name: 'Bob' } };
+    const reply: any = { cookie: jest.fn(), redirect: jest.fn() };
+    await controller.googleAuthRedirect(req, reply);
+    expect(authService.createExternalAccessToken).toHaveBeenCalledWith(
+      { sub: 'bob@test.com', username: 'bob@test.com', name: 'Bob' },
+      'gid',
+      AuthProvider.Google,
+    );
+    expect(reply.cookie).toHaveBeenCalledWith('sid', 'token', { httpOnly: true, secure: false, sameSite: 'lax' });
+    expect(reply.redirect).toHaveBeenCalledWith('/home');
+  });
+});

--- a/src/locksmith.module.ts
+++ b/src/locksmith.module.ts
@@ -54,7 +54,10 @@ export interface LocksmithModuleOptions {
   };
   /** Optional path used by OAuth controllers for the final redirect */
   redirectPath?: string;
-  /** Express cookie options used when setting the session cookie */
+  /**
+   * Cookie options used when setting or clearing the session cookie.
+   * Compatible with Express and Fastify (@fastify/cookie).
+   */
   cookieOptions?: import('express').CookieOptions;
 }
 


### PR DESCRIPTION
## Summary
- clarify cookie options to mention Express and Fastify
- document cookie handling for Express and Fastify in README
- add fastify compatibility unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c5a444d6083229026f4beabf2e68e