### PR TITLE
Increase unit test coverage

### DIFF
--- a/src/controllers/index.spec.ts
+++ b/src/controllers/index.spec.ts
@@ -1,0 +1,12 @@
+import * as controllers from './index';
+import { GoogleOauthController } from './google-auth.controller';
+import { MicrosoftOauthController } from './microsoft-auth.controller';
+import { AppleOauthController } from './apple-auth.controller';
+
+describe('controllers index', () => {
+  it('re-exports controller classes', () => {
+    expect(controllers.GoogleOauthController).toBe(GoogleOauthController);
+    expect(controllers.MicrosoftOauthController).toBe(MicrosoftOauthController);
+    expect(controllers.AppleOauthController).toBe(AppleOauthController);
+  });
+});

--- a/src/guards/index.spec.ts
+++ b/src/guards/index.spec.ts
@@ -1,0 +1,14 @@
+import * as guards from './index';
+import { JwtAuthGuard } from './jwt.guard';
+import { GoogleAuthGuard } from './google-auth.guard';
+import { MicrosoftAuthGuard } from './microsoft-auth.guard';
+import { AppleAuthGuard } from './apple-auth.guard';
+
+describe('guards index', () => {
+  it('re-exports guard classes', () => {
+    expect(guards.JwtAuthGuard).toBe(JwtAuthGuard);
+    expect(guards.GoogleAuthGuard).toBe(GoogleAuthGuard);
+    expect(guards.MicrosoftAuthGuard).toBe(MicrosoftAuthGuard);
+    expect(guards.AppleAuthGuard).toBe(AppleAuthGuard);
+  });
+});

--- a/src/locksmith.module.spec.ts
+++ b/src/locksmith.module.spec.ts
@@ -1,0 +1,46 @@
+import { LocksmithModule } from './locksmith.module';
+import { GoogleOauthController } from './controllers/google-auth.controller';
+import { MicrosoftOauthController } from './controllers/microsoft-auth.controller';
+import { JwtAuthGuard } from './guards/jwt.guard';
+import { JwtAuthStrategy } from './strategies/jwt.strategy';
+import { MicrosoftAuthGuard } from './guards/microsoft-auth.guard';
+import { MicrosoftAuthStrategy } from './strategies/microsoft-auth.strategy';
+
+class TestFactory {
+  createLocksmithOptions() {
+    return {
+      jwt: { secret: 'f', expiresIn: 1, sessionCookieName: 'sid' },
+      external: { microsoft: { clientID: 'id', clientSecret: 'sec', callbackURL: 'cb' } },
+    } as any;
+  }
+}
+
+describe('LocksmithModule', () => {
+  it('forRoot configures providers and controllers', () => {
+    const mod = LocksmithModule.forRoot({
+      jwt: { secret: 'a', expiresIn: 1, sessionCookieName: 'sid' },
+      external: { google: { clientID: 'id', clientSecret: 'sec', callbackURL: 'cb' } },
+    });
+    expect(mod.controllers).toEqual([GoogleOauthController]);
+    expect(mod.imports?.length).toBe(1);
+    expect(mod.providers).toEqual(
+      expect.arrayContaining([JwtAuthGuard, JwtAuthStrategy])
+    );
+  });
+
+  it('forRootAsync loads options from factory', async () => {
+    const mod = await LocksmithModule.forRootAsync({
+      useFactory: async () => ({ jwt: { secret: 'x', expiresIn: 1, sessionCookieName: 'sid' } }),
+    });
+    expect(mod.imports?.length).toBe(1);
+    expect(mod.providers).toEqual(expect.arrayContaining([JwtAuthGuard, JwtAuthStrategy]));
+  });
+
+  it('forRootAsync loads options from class', async () => {
+    const mod = await LocksmithModule.forRootAsync({ useClass: TestFactory });
+    expect(mod.controllers).toEqual([MicrosoftOauthController]);
+    expect(mod.providers).toEqual(
+      expect.arrayContaining([MicrosoftAuthGuard, MicrosoftAuthStrategy])
+    );
+  });
+});

--- a/src/services/locksmith-auth.service.spec.ts
+++ b/src/services/locksmith-auth.service.spec.ts
@@ -2,6 +2,7 @@ import { Test } from '@nestjs/testing';
 import { JwtModule, JwtService } from '@nestjs/jwt';
 import { LocksmithAuthService } from './locksmith-auth.service';
 import { JwtPayload } from '../strategies/jwt.strategy';
+import { AuthProvider } from '../enums';
 
 describe('LocksmithAuthService', () => {
   it('creates tokens with default iss and jti', async () => {
@@ -66,5 +67,72 @@ describe('LocksmithAuthService', () => {
       path: '/app',
       domain: 'example.com',
     });
+  });
+
+  it('createExternalAccessToken uses package.json name when issuer is missing', async () => {
+    const fs = await import('fs');
+    const os = await import('os');
+    const path = await import('path');
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ls-'));
+    fs.writeFileSync(path.join(tempDir, 'package.json'), JSON.stringify({ name: 'test-app' }));
+    const cwd = process.cwd();
+    process.chdir(tempDir);
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [JwtModule.register({ secret: 'test' })],
+      providers: [
+        LocksmithAuthService,
+        { provide: 'LOCKSMITH_OPTIONS', useValue: { jwt: {} } },
+      ],
+    }).compile();
+
+    const service = moduleRef.get<LocksmithAuthService>(LocksmithAuthService);
+    const jwtService = moduleRef.get(JwtService);
+
+    const payload: JwtPayload = { sub: '1', username: 'bob' };
+    const { accessToken } = await service.createExternalAccessToken(
+      payload,
+      'ext',
+      AuthProvider.Google,
+    );
+    const decoded = jwtService.verify(accessToken) as any;
+    expect(decoded.iss).toBe('test-app');
+    expect(decoded.externalId).toBe('ext');
+    expect(decoded.provider).toBe(AuthProvider.Google);
+
+    process.chdir(cwd);
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('createExternalAccessToken omits issuer when package.json missing', async () => {
+    const fs = await import('fs');
+    const os = await import('os');
+    const path = await import('path');
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ls-'));
+    const cwd = process.cwd();
+    process.chdir(tempDir);
+
+    const moduleRef = await Test.createTestingModule({
+      imports: [JwtModule.register({ secret: 'test' })],
+      providers: [
+        LocksmithAuthService,
+        { provide: 'LOCKSMITH_OPTIONS', useValue: { jwt: {} } },
+      ],
+    }).compile();
+
+    const service = moduleRef.get<LocksmithAuthService>(LocksmithAuthService);
+    const jwtService = moduleRef.get(JwtService);
+    const payload: JwtPayload = { sub: '1', username: 'alice' };
+    const { accessToken } = await service.createExternalAccessToken(
+      payload,
+      'ext2',
+      AuthProvider.Apple,
+    );
+    const decoded = jwtService.verify(accessToken) as any;
+    expect(decoded.iss).toBeUndefined();
+    expect(decoded.provider).toBe(AuthProvider.Apple);
+
+    process.chdir(cwd);
+    fs.rmSync(tempDir, { recursive: true, force: true });
   });
 });

--- a/src/strategies/index.spec.ts
+++ b/src/strategies/index.spec.ts
@@ -1,0 +1,14 @@
+import * as strategies from './index';
+import { GoogleAuthStrategy } from './google-auth.strategy';
+import { MicrosoftAuthStrategy } from './microsoft-auth.strategy';
+import { AppleAuthStrategy } from './apple-auth.strategy';
+import { JwtAuthStrategy } from './jwt.strategy';
+
+describe('strategies index', () => {
+  it('re-exports strategy classes', () => {
+    expect(strategies.GoogleAuthStrategy).toBe(GoogleAuthStrategy);
+    expect(strategies.MicrosoftAuthStrategy).toBe(MicrosoftAuthStrategy);
+    expect(strategies.AppleAuthStrategy).toBe(AppleAuthStrategy);
+    expect(strategies.JwtAuthStrategy).toBe(JwtAuthStrategy);
+  });
+});

--- a/src/strategies/jwt.strategy.spec.ts
+++ b/src/strategies/jwt.strategy.spec.ts
@@ -1,0 +1,23 @@
+import { JwtAuthStrategy } from './jwt.strategy';
+
+describe('JwtAuthStrategy', () => {
+  const options = { jwt: { secret: 'test', sessionCookieName: 'sid' } } as any;
+
+  it('extracts token from request cookies', () => {
+    const strategy = new JwtAuthStrategy(options);
+    const token = (strategy as any)._jwtFromRequest({ cookies: { sid: 'abc' } });
+    expect(token).toBe('abc');
+  });
+
+  it('returns empty string when cookie missing', () => {
+    const strategy = new JwtAuthStrategy(options);
+    const token = (strategy as any)._jwtFromRequest({});
+    expect(token).toBe('');
+  });
+
+  it('validate returns payload', () => {
+    const strategy = new JwtAuthStrategy(options);
+    const payload = { sub: '1', username: 'bob' };
+    expect(strategy.validate(payload)).toEqual(payload);
+  });
+});


### PR DESCRIPTION
## Summary
- expand LocksmithAuthService tests for issuer resolution
- add JwtAuthStrategy, index, and LocksmithModule unit tests

## Testing
- `npm test`
- `npm run test:cov`


------
https://chatgpt.com/codex/tasks/task_e_684cbe843dcc8322a24bb1e371f7cc60