### PR TITLE
Update NestJS dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@nestjs/common": "^11.0.16",
-        "@nestjs/core": "^11.0.1",
+        "@nestjs/common": "^11.1.3",
+        "@nestjs/core": "^11.1.3",
         "@nestjs/jwt": "^11.0.0",
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.1.3",
@@ -27,9 +27,9 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3.2.0",
         "@eslint/js": "^9.18.0",
-        "@nestjs/cli": "^11.0.0",
-        "@nestjs/schematics": "^11.0.0",
-        "@nestjs/testing": "^11.0.1",
+        "@nestjs/cli": "^11.0.7",
+        "@nestjs/schematics": "^11.0.5",
+        "@nestjs/testing": "^11.1.3",
         "@swc/cli": "^0.6.0",
         "@swc/core": "^1.10.7",
         "@types/express": "^5.0.0",
@@ -52,6 +52,9 @@
         "tsconfig-paths": "^4.2.0",
         "typescript": "^5.7.3",
         "typescript-eslint": "^8.20.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "pretest": "node scripts/check-deps.js"
   },
   "dependencies": {
-    "@nestjs/common": "^11.0.16",
-    "@nestjs/core": "^11.0.1",
+    "@nestjs/common": "^11.1.3",
+    "@nestjs/core": "^11.1.3",
     "@nestjs/jwt": "^11.0.0",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.1.3",
@@ -41,9 +41,9 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",
     "@eslint/js": "^9.18.0",
-    "@nestjs/cli": "^11.0.0",
-    "@nestjs/schematics": "^11.0.0",
-    "@nestjs/testing": "^11.0.1",
+    "@nestjs/cli": "^11.0.7",
+    "@nestjs/schematics": "^11.0.5",
+    "@nestjs/testing": "^11.1.3",
     "@swc/cli": "^0.6.0",
     "@swc/core": "^1.10.7",
     "@types/express": "^5.0.0",


### PR DESCRIPTION
## Summary
- bump NestJS core packages to 11.1.3
- update Nest CLI and dev dependencies for 11.x series

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cc2255d448322b0cf5a35e2b754fe