### PR TITLE
feat: Add GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,24 @@
+name: Build 🏗️
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+    - main
+    paths:
+      - 'src/**'
+      - '.github/workflows/build.yml'
+      - 'package.json'
+      - 'tsconfig.json'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+      - name: Install Dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,23 @@
+name: Publish 🚀
+permissions:
+  id-token: write
+on:
+  release:
+    types: [published]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Install Dependencies
+        run: npm ci
+      - name: Build 🏗️
+        run: npm run build
+      - name: Publish
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Test 🧪
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+    - main
+    paths:
+      - 'src/**'
+      - '.github/workflows/test.yml'
+      - 'package.json'
+      - 'tsconfig.json'
+      - 'jest.config.js'
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+      - run: npm install
+      - name: Run Unit Tests
+        run: npm run test:cov
+      - name: Upload Test Coverage to Codecov
+        uses: codecov/codecov-action@v4.0.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This pull request introduces three new GitHub Actions workflows to automate the build, test, and publish processes for the project. These workflows ensure consistent CI/CD practices and streamline the development pipeline.

### CI/CD Workflow Additions:

* **Build Workflow**:
  - Added `.github/workflows/build.yml` to handle builds triggered by pull requests, pushes to the `main` branch, or manual dispatch. It installs dependencies and runs the build script.

* **Publish Workflow**:
  - Added `.github/workflows/publish.yml` to automate publishing to npm upon release events. It includes steps for building the project and publishing with provenance and public access, using an npm token stored in secrets.

* **Test Workflow**:
  - Added `.github/workflows/test.yml` to run unit tests on pull requests, pushes to the `main` branch, or manual dispatch. It installs dependencies, runs tests with coverage, and uploads coverage reports to Codecov.