### PR TITLE
Normalize Apple & Microsoft OAuth payloads

### DIFF
--- a/src/controllers/apple-auth.controller.ts
+++ b/src/controllers/apple-auth.controller.ts
@@ -25,12 +25,18 @@ export class AppleOauthController {
   @Get('redirect')
   @UseGuards(AppleAuthGuard)
   async appleAuthRedirect(@Req() req, @Res() res): Promise<any> {
-  	/* eslint-disable @typescript-eslint/no-unsafe-argument */
-  	const accessToken = await this.authService.createExternalAccessToken(
-  		req.user,
-  		req.user?.providerId,
-  		AuthProvider.Apple,
-  	);
+        /* eslint-disable @typescript-eslint/no-unsafe-argument */
+        const payload = {
+                sub: req.user?.username,
+                username: req.user?.username,
+                name: req.user?.name,
+        };
+
+        const accessToken = await this.authService.createExternalAccessToken(
+                payload,
+                req.user?.providerId,
+                AuthProvider.Apple,
+        );
 
   	const cookieOpts = {
   		httpOnly: true,

--- a/src/controllers/microsoft-auth.controller.ts
+++ b/src/controllers/microsoft-auth.controller.ts
@@ -25,12 +25,18 @@ export class MicrosoftOauthController {
   @Get('redirect')
   @UseGuards(MicrosoftAuthGuard)
   async microsoftAuthRedirect(@Req() req, @Res() res): Promise<any> {
-  	/* eslint-disable @typescript-eslint/no-unsafe-argument */
-  	const accessToken = await this.authService.createExternalAccessToken(
-  		req.user,
-  		req.user?.providerId,
-  		AuthProvider.Microsoft,
-  	);
+        /* eslint-disable @typescript-eslint/no-unsafe-argument */
+        const payload = {
+                sub: req.user?.username,
+                username: req.user?.username,
+                name: req.user?.name,
+        };
+
+        const accessToken = await this.authService.createExternalAccessToken(
+                payload,
+                req.user?.providerId,
+                AuthProvider.Microsoft,
+        );
 
   	const cookieOpts = {
   		httpOnly: true,

--- a/src/controllers/oauth-controllers.spec.ts
+++ b/src/controllers/oauth-controllers.spec.ts
@@ -46,20 +46,20 @@ describe('OAuth Controllers', () => {
 		expect(res.redirect).toHaveBeenCalledWith('/home');
 	});
 
-	it('microsoftAuthRedirect creates token and sets cookie', async () => {
-		const controller = new MicrosoftOauthController(
-			options,
+        it('microsoftAuthRedirect creates token and sets cookie', async () => {
+                const controller = new MicrosoftOauthController(
+                        options,
       authService as unknown as ILocksmithAuthService,
-		);
-		const req: any = {
-			user: { providerId: 'mid', username: 'alice@ms.com', name: 'Alice' },
-		};
-		await controller.microsoftAuthRedirect(req, res as any);
-		expect(authService.createExternalAccessToken).toHaveBeenCalledWith(
-			req.user,
-			'mid',
-			AuthProvider.Microsoft,
-		);
+                );
+                const req: any = {
+                        user: { providerId: 'mid', username: 'alice@ms.com', name: 'Alice' },
+                };
+                await controller.microsoftAuthRedirect(req, res as any);
+                expect(authService.createExternalAccessToken).toHaveBeenCalledWith(
+                        { sub: 'alice@ms.com', username: 'alice@ms.com', name: 'Alice' },
+                        'mid',
+                        AuthProvider.Microsoft,
+                );
 		expect(res.cookie).toHaveBeenCalledWith('sid', 'token', {
 			secure: true,
 			httpOnly: true,
@@ -68,20 +68,20 @@ describe('OAuth Controllers', () => {
 		expect(res.redirect).toHaveBeenCalledWith('/home');
 	});
 
-	it('appleAuthRedirect creates token and sets cookie', async () => {
-		const controller = new AppleOauthController(
-			options,
+        it('appleAuthRedirect creates token and sets cookie', async () => {
+                const controller = new AppleOauthController(
+                        options,
       authService as unknown as ILocksmithAuthService,
-		);
-		const req: any = {
-			user: { providerId: 'aid', username: 'apple@test.com' },
-		};
-		await controller.appleAuthRedirect(req, res as any);
-		expect(authService.createExternalAccessToken).toHaveBeenCalledWith(
-			req.user,
-			'aid',
-			AuthProvider.Apple,
-		);
+                );
+                const req: any = {
+                        user: { providerId: 'aid', username: 'apple@test.com' },
+                };
+                await controller.appleAuthRedirect(req, res as any);
+                expect(authService.createExternalAccessToken).toHaveBeenCalledWith(
+                        { sub: 'apple@test.com', username: 'apple@test.com', name: undefined },
+                        'aid',
+                        AuthProvider.Apple,
+                );
 		expect(res.cookie).toHaveBeenCalledWith('sid', 'token', {
 			secure: true,
 			httpOnly: true,


### PR DESCRIPTION
## Summary
- normalize Apple and Microsoft OAuth payloads
- expect normalized payloads in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d194ef9448322aed1deb4394aa576