### PR TITLE
Update README redirectPath examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,11 @@ LocksmithModule.forRoot({
 ```
 
 Optionally, `redirectPath` controls where users are redirected after a successful
-OAuth login. `cookieOptions` are forwarded to the Express `response.cookie`
-method or Fastify's `reply.cookie` when setting and clearing the session cookie.
+OAuth login. This can be a relative path or an absolute URL. For example, you can set
+`redirectPath: 'https://portal.example.org/profile'` to send users to a different domain
+after login. `cookieOptions` are forwarded to the Express `response.cookie`
+method or Fastify's `reply.cookie` when setting and clearing the session cookie, and may
+include a `domain` property if the cookie should be shared across subdomains.
 
 Alternatively, you can load configuration asynchronously using Nest's
 `ConfigModule`:


### PR DESCRIPTION
## Summary
- clarify that `redirectPath` accepts an absolute URL with example redirecting to a different domain
- mention that `cookieOptions` may include a `domain` property for cross-subdomain cookies

## Testing
- `npm run test`
- `npm run test:cov`


------
https://chatgpt.com/codex/tasks/task_e_684d197310808322afdf458a2f78e8b6